### PR TITLE
Fix problem with testing click CLI output

### DIFF
--- a/pynpm/utils.py
+++ b/pynpm/utils.py
@@ -22,8 +22,6 @@ def run_npm(pkgdir, cmd, args=None, npm_bin='npm', wait=True):
     if wait:
         return subprocess.call(
             command,
-            stdout=sys.stdout,
-            stderr=sys.stderr,
             cwd=pkgdir,
         )
     else:


### PR DESCRIPTION
* Using sys.stdout/stderror with subprocess.call caused click testing
  CLIRunner to fail when NPM writes to stdout, since CLIRunner wraps
  stdout with a stream that does not support fileno which is required by
  subprocess.call.