### PR TITLE
add a shell option to NPM class

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,8 +33,8 @@ jobs:
           python-version: [3.7, 3.8, 3.9]
           requirements-level: [pypi]
           include:
-            os: windows-latest
-            python-version: 3.9
+            - os: windows-latest
+              python-version: 3.9
     runs-on: ${{ matrix.os }}
     env:
       EXTRAS: tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,13 +26,16 @@ on:
 
 jobs:
   Tests:
-    runs-on: ubuntu-20.04
     timeout-minutes: 20
     strategy:
       matrix:
+          os: ubuntu-20.04
           python-version: [3.7, 3.8, 3.9]
           requirements-level: [pypi]
-
+          include:
+            os: windows-latest
+            python-version: 3.9
+    runs-on: ${{ matrix.os }}
     env:
       EXTRAS: tests
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-          os: ubuntu-20.04
+          os: [ubuntu-20.04]
           python-version: [3.7, 3.8, 3.9]
           requirements-level: [pypi]
           include:

--- a/README.rst
+++ b/README.rst
@@ -85,3 +85,24 @@ You can also run other NPM commands or restrict which commands you can run:
 .. code-block:: python
 
     pkg = NPMPackage('path/to/package.json', commands=['install'])
+
+Trouble shooting
+================
+
+Windows user may face the following error when running the ``NPM`` command:
+
+.. code-block:: console
+
+    [WinError 2] The system cannot find the file specified
+
+It means supbrossess is unable to run the specific command. To fix this issue, 
+use the ``shell=True`` option uppon class initialization:
+
+.. code-block:: python
+
+    pkg = NPMPackage('path/to/package.json', shell=True)
+
+.. danger:: 
+
+    This option is not recommended for security reasons. It should only be used
+    on trusted inputs.

--- a/pynpm/package.py
+++ b/pynpm/package.py
@@ -24,9 +24,10 @@ class NPMPackage(object):
     :param filepath: Path to ``package.json`` or directory containing the file.
     :param npm_bin: Path to NPM binary. Defaults to ``npm``.
     :param commands: List of allowed NPM commands to invoke.
+    :param shell: Run NPM in a shell. Defaults to ``False``.
     """
 
-    def __init__(self, filepath, npm_bin="npm", commands=None):
+    def __init__(self, filepath, npm_bin="npm", commands=None, shell=False):
         """Initialize package."""
         self._commands = commands or [
             "build",
@@ -41,6 +42,7 @@ class NPMPackage(object):
         self._package_json_path = filepath
         self._package_json_contents = None
         self._npm_bin = npm_bin
+        self._shell = shell
 
     @property
     def package_json_path(self):
@@ -73,6 +75,7 @@ class NPMPackage(object):
             command,
             npm_bin=self._npm_bin,
             args=args,
+            shell=self._shell,
             **kwargs
         )
 

--- a/pynpm/package.py
+++ b/pynpm/package.py
@@ -90,8 +90,8 @@ class NPMPackage(object):
 class YarnPackage(NPMPackage):
     """Yarn package."""
 
-    def __init__(self, filepath, yarn_bin="yarn", commands=None):
+    def __init__(self, filepath, yarn_bin="yarn", commands=None, shell=False):
         """Initialize package."""
         super(YarnPackage, self).__init__(
-            filepath, npm_bin=yarn_bin, commands=commands or ["install"]
+            filepath, npm_bin=yarn_bin, commands=commands or ["install"], shell=shell
         )

--- a/pynpm/utils.py
+++ b/pynpm/utils.py
@@ -18,7 +18,11 @@ def run_npm(pkgdir, cmd, args=None, npm_bin="npm", wait=True, shell=False):
     """Run NPM."""
     command = [npm_bin, cmd] + list(args)
     if wait:
-        return subprocess.call(command, cwd=pkgdir, shell=shell,)
+        return subprocess.call(
+            command,
+            cwd=pkgdir,
+            shell=shell,
+        )
     else:
         return subprocess.Popen(
             command,

--- a/pynpm/utils.py
+++ b/pynpm/utils.py
@@ -11,9 +11,7 @@
 
 from __future__ import absolute_import, print_function
 
-import os
 import subprocess
-import sys
 
 
 def run_npm(pkgdir, cmd, args=None, npm_bin="npm", wait=True, shell=False):

--- a/pynpm/utils.py
+++ b/pynpm/utils.py
@@ -20,11 +20,7 @@ def run_npm(pkgdir, cmd, args=None, npm_bin="npm", wait=True, shell=False):
     """Run NPM."""
     command = [npm_bin, cmd] + list(args)
     if wait:
-        return subprocess.call(
-            command,
-            cwd=pkgdir,
-            shell=shell,
-        )
+        return subprocess.call(command, cwd=pkgdir, shell=shell,)
     else:
         return subprocess.Popen(
             command,

--- a/pynpm/utils.py
+++ b/pynpm/utils.py
@@ -16,13 +16,14 @@ import subprocess
 import sys
 
 
-def run_npm(pkgdir, cmd, args=None, npm_bin="npm", wait=True):
+def run_npm(pkgdir, cmd, args=None, npm_bin="npm", wait=True, shell=False):
     """Run NPM."""
     command = [npm_bin, cmd] + list(args)
     if wait:
         return subprocess.call(
             command,
             cwd=pkgdir,
+            shell=shell,
         )
     else:
         return subprocess.Popen(
@@ -30,4 +31,5 @@ def run_npm(pkgdir, cmd, args=None, npm_bin="npm", wait=True):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             cwd=pkgdir,
+            shell=shell,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,6 @@ import shutil
 import tempfile
 from os.path import dirname, join
 
-import pkg_resources
 import pytest
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,8 @@ from os.path import dirname, join
 import pkg_resources
 import pytest
 
+from pynpm import NPMPackage, YarnPackage
+
 
 @pytest.yield_fixture()
 def tmpdir():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,8 +19,6 @@ from os.path import dirname, join
 import pkg_resources
 import pytest
 
-from pynpm import NPMPackage, YarnPackage
-
 
 @pytest.yield_fixture()
 def tmpdir():

--- a/tests/test_pynpm.py
+++ b/tests/test_pynpm.py
@@ -10,12 +10,16 @@
 """Module tests."""
 
 from __future__ import absolute_import, print_function
-
 from os.path import dirname
+import platform
 
 import pytest
 
 from pynpm import NPMPackage, YarnPackage
+
+# create a global variable to check if we are on windows
+# it will pilot the shell option to run the tests
+is_windows = platform.system() == "Windows"
 
 
 def test_version():
@@ -27,39 +31,39 @@ def test_version():
 
 def test_package_json(pkg, pkgjson_source):
     """Test package JSON content."""
-    npmpkg = NPMPackage(pkg)
+    npmpkg = NPMPackage(pkg, shell=is_windows)
     assert npmpkg.package_json == pkgjson_source
 
 
 def test_package_json_path(pkg):
     """Test package JSON content."""
-    npmpkg = NPMPackage(pkg)
+    npmpkg = NPMPackage(pkg, shell=is_windows)
     assert npmpkg.package_json_path == pkg
-    npmpkg = NPMPackage(dirname(pkg))
+    npmpkg = NPMPackage(dirname(pkg), shell=is_windows)
     assert npmpkg.package_json_path == pkg
 
 
 def test_nonexsting_command(pkg):
     """Test non-existing command."""
-    npmpkg = NPMPackage(pkg)
+    npmpkg = NPMPackage(pkg, shell=is_windows)
     pytest.raises(AttributeError, getattr, npmpkg, "cmd_doesnotexists")
 
 
 def test_disabled_command(pkg):
     """Test command that has been disabled."""
-    npmpkg = NPMPackage(pkg, commands=["run-script"])
+    npmpkg = NPMPackage(pkg, commands=["run-script"], shell=is_windows)
     pytest.raises(AttributeError, getattr, npmpkg, "install")
 
 
 def test_command(pkg):
     """Test non-existing command."""
-    npmpkg = NPMPackage(pkg)
+    npmpkg = NPMPackage(pkg, shell=is_windows)
     assert npmpkg.run_script("test") == 0
 
 
 def test_command_nowait(pkg):
     """Test non-existing command."""
-    npmpkg = NPMPackage(pkg)
+    npmpkg = NPMPackage(pkg, shell=is_windows)
     proc = npmpkg.run_script("test", wait=False)
     # Just check output of last line
     for line in proc.stdout:
@@ -69,7 +73,7 @@ def test_command_nowait(pkg):
 
 def test_command_install(pkg, deppkg):
     """Test non-existing command."""
-    npmpkg = NPMPackage(pkg)
+    npmpkg = NPMPackage(pkg, shell=is_windows)
     assert npmpkg.install() == 0
 
 
@@ -78,3 +82,10 @@ def test_command_install_yarn(pkg, deppkg):
     yarnpkg = YarnPackage(pkg)
     assert yarnpkg.install() == 0
 
+@pytest.mark.skipif(not is_windows, reason="Simply check a known Windows bug")
+def test_command_windows_fail_without_shell(pkg):
+    """Test that command does not work on windows without the shell option."""
+    
+    with pytest.raises(FileNotFoundError): 
+        npmpkg = NPMPackage(pkg)
+        assert npmpkg.install() == 0

--- a/tests/test_pynpm.py
+++ b/tests/test_pynpm.py
@@ -77,6 +77,7 @@ def test_command_install(pkg, deppkg):
     npmpkg = NPMPackage(pkg, shell=is_windows)
     assert npmpkg.install() == 0
 
+
 @pytest.mark.skipif(is_windows, reason="Yarn is not yet working on windows")
 def test_command_install_yarn(pkg, deppkg):
     """Test yarn install."""

--- a/tests/test_pynpm.py
+++ b/tests/test_pynpm.py
@@ -77,3 +77,4 @@ def test_command_install_yarn(pkg, deppkg):
     """Test yarn install."""
     yarnpkg = YarnPackage(pkg)
     assert yarnpkg.install() == 0
+

--- a/tests/test_pynpm.py
+++ b/tests/test_pynpm.py
@@ -10,8 +10,9 @@
 """Module tests."""
 
 from __future__ import absolute_import, print_function
-from os.path import dirname
+
 import platform
+from os.path import dirname
 
 import pytest
 
@@ -79,13 +80,14 @@ def test_command_install(pkg, deppkg):
 
 def test_command_install_yarn(pkg, deppkg):
     """Test yarn install."""
-    yarnpkg = YarnPackage(pkg)
+    yarnpkg = YarnPackage(pkg, shell=is_windows)
     assert yarnpkg.install() == 0
+
 
 @pytest.mark.skipif(not is_windows, reason="Simply check a known Windows bug")
 def test_command_windows_fail_without_shell(pkg):
     """Test that command does not work on windows without the shell option."""
-    
-    with pytest.raises(FileNotFoundError): 
+
+    with pytest.raises(FileNotFoundError):
         npmpkg = NPMPackage(pkg)
         assert npmpkg.install() == 0

--- a/tests/test_pynpm.py
+++ b/tests/test_pynpm.py
@@ -77,7 +77,7 @@ def test_command_install(pkg, deppkg):
     npmpkg = NPMPackage(pkg, shell=is_windows)
     assert npmpkg.install() == 0
 
-
+@pytest.mark.skipif(is_windows, reason="Yarn is not yet working on windows")
 def test_command_install_yarn(pkg, deppkg):
     """Test yarn install."""
     yarnpkg = YarnPackage(pkg, shell=is_windows)


### PR DESCRIPTION
Fix #12 

As mentioned in the related issue, the error is comming from the windows systems not being able to find the NPM command. 
I propagated the changes suggested by @travisjwalter and updated the doc accordingly.

Fix #14 

To check that my changes are making sense I also added a windows test in the test suit.