### PR TITLE
ci: remove babel-compile-catalog from PyPI publish

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -18,5 +18,3 @@ jobs:
   build-n-publish:
     uses: inveniosoftware/workflows/.github/workflows/pypi-publish.yml@master
     secrets: inherit
-    with:
-      babel-compile-catalog: true

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2025 KTH Royal Institute of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -14,28 +15,8 @@ on:
       - v*
 
 jobs:
-  Publish:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel babel
-
-      - name: Build package
-        run: |
-          python setup.py sdist bdist_wheel
-
-      - name: Publish on PyPI
-        uses: pypa/gh-action-pypi-publish@v1.3.1
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_token }}
+  build-n-publish:
+    uses: inveniosoftware/workflows/.github/workflows/pypi-publish.yml@master
+    secrets: inherit
+    with:
+      babel-compile-catalog: true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changes
 =======
 
-Version <next>
+Version 0.3.0 (released 2025-02-20)
 
 - Add ``PNPMPackage``
 

--- a/pynpm/__init__.py
+++ b/pynpm/__init__.py
@@ -14,6 +14,6 @@ from __future__ import absolute_import, print_function
 
 from .package import NPMPackage, PNPMPackage, YarnPackage
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = ("__version__", "NPMPackage", "PNPMPackage", "YarnPackage")


### PR DESCRIPTION
Looks like the enabled babel operation broke the latest 0.3.0 release attempt. This PR disables that part of the PyPI flow ([default is disabled](https://github.com/inveniosoftware/workflows/blob/master/.github/workflows/pypi-publish.yml#L13)).